### PR TITLE
removed ? from 'fantastic' - there is a bug here

### DIFF
--- a/Briar/features/calabash_predefined/predefined_text_field.feature
+++ b/Briar/features/calabash_predefined/predefined_text_field.feature
@@ -19,8 +19,8 @@ Feature: testing the text field set_text, clear_text, and predefined steps
     Then I should see "top tf" text field with text ""
 
     # predefined
-    Then I enter "fantastic?" into the "top tf" input field
-    Then I should see "top tf" text field with text "fantastic?"
+    Then I enter "fantastic" into the "top tf" input field
+    Then I should see "top tf" text field with text "fantastic"
     When I clear "top tf"
     Then I should see "top tf" text field with text ""
 


### PR DESCRIPTION
## Motivation

This test flickers in CI.

```
Then I enter "fantastic?" into the "top tf" input field
Then I should see "top tf" text field with text "fantastic?"
i expected to see text field named 'top tf' with text 'fantastic?' but found 'fantastiC?' (RuntimeError)
```

I cannot reproduce locally.

I _think_ what is happening is the shift key is touched too early?  How is that even possible?

Instead of typing 'fantastic?', I type 'fantastic'.
### Not Reproducible in Instruments.app

I have been running this script on my machine today, but no failures yet.

```
var expected = "fantastic?";

for (i = 0; i < 1200; i++) { 
    UIALogger.logDebug("starting iteration: " + i)
    target.frontMostApp().mainWindow().elements()["text related"].textFields()["bottom tf"].tap();
    target.delay(0.4)
    target.frontMostApp().keyboard().typeString(expected);
    target.delay(0.4)
    target.frontMostApp().navigationBar().rightButton().tap();
    target.delay(0.4)
    var actual = target.frontMostApp().mainWindow().elements()["text related"].textFields()["bottom tf"].value();
    if (actual != expected) {
        msg = "expected '" + expected + "' but found '" + actual + "'";
        throw msg;
    }
    target.delay(0.4);
}
```
### Notes on Instruments Run
- Throws lots of unrelated exceptions:  _e.g._ `failed to type 's'`.
- There seems to be a difference between passing a variable or string literal to typeString; passing a literal is more stable.

```
//  pass a variable
var expected = "fantastic?";
target.frontMostApp().keyboard().typeString(expected);

// pass a literal
target.frontMostApp().keyboard().typeString("fantastic");
```
## todo
- [ ] @krukow  Any insights?
- [ ] @jmoody Create an issue and write a test that demonstrates the problem
