### PR TITLE
use progress cuke formatter and stop sim in ci

### DIFF
--- a/Briar/config/cucumber.yml
+++ b/Briar/config/cucumber.yml
@@ -28,6 +28,14 @@ device_list.each do |device|
   FileUtils.mkdir("./reports/#{device}/screenshots") unless File.exists?("./reports/#{device}/screenshots")
 end
 
+if ENV["USER"] == "jenkins"
+  formatter = "progress"
+  keep_sim_open_after = "0"
+else
+  formatter = "Slowhandcuke::Formatter"
+  keep_sim_open_after = "1"
+end
+
 default_report = "./reports/calabash-#{date}.html"
 ss_path = "./screenshots/"
 
@@ -35,7 +43,7 @@ ss_path = "./screenshots/"
 %>
 
 verbose: CALABASH_FULL_CONSOLE_OUTPUT=1 DEBUG=1
-common: -f pretty --expand --no-multiline --no-source
+common: -f <%= formatter %> NO_STOP=<%= keep_sim_open_after %> --expand --no-multiline --no-source
 
 ss_path: SCREENSHOT_PATH=<%= ss_path %>
 
@@ -54,14 +62,12 @@ no_launch:    NO_LAUNCH=1 --tags ~@launch
 do_launch:    NO_LAUNCH=0 --tags ~@no_launch
 no_reset_btw: RESET_BETWEEN_SCENARIOS=0
 reset_btw:    RESET_BETWEEN_SCENARIOS=1
-stop:         NO_STOP=0
-no_stop:      NO_STOP=1
 
 ipad:   DEVICE=ipad   -p common --tags ~@iphone --tags ~@iphone_only
 iphone: DEVICE=iphone -p common --tags ~@ipad --tags ~@ipad_only
 
 simulator:     -p common -p ss_path -p html_report --tags ~@device_only --tags ~@device
-sim_launch:    -p simulator -p do_launch -p no_reset_btw -p no_stop
+sim_launch:    -p simulator -p do_launch -p no_reset_btw
 sim_no_launch: -p simulator -p no_launch -p no_reset_btw
 
 sim61:     -p sim_launch    DEVICE_TARGET='iPhone (3.5-inch) - Simulator - iOS 6.1'
@@ -96,7 +102,7 @@ sim71_ipad_r_64b:  -p sim_launch DEVICE_TARGET='iPad Retina (64-bit) - Simulator
 
 default:    -p sim71_4in
 
-no_uia:   -p common -p ss_path -p html_report -p no_launch -p no_reset_btw            -p sim61_4in
+no_uia:   -p common -p ss_path -p html_report -p no_launch -p no_reset_btw -p sim61_4in
 
 # required only for devices
 bundle_id:    BUNDLE_ID=com.littlejoysoftware.Briar-cal
@@ -111,11 +117,11 @@ neptune_common: DEVICE_TARGET=<%= devices[:neptune][:udid] %> DEVICE_ENDPOINT=<%
 
 # cannot test email views without launching on iOS 6
 neptune:        -p neptune_common -p no_launch --tags ~@email
-neptune_launch: -p neptune_common -p do_launch -p no_stop
+neptune_launch: -p neptune_common -p do_launch
 
 venus_common:   DEVICE_TARGET=<%= devices[:venus][:udid] %>   DEVICE_ENDPOINT=<%= devices[:venus][:ip] %> -p device_common -p ipad   -p venus_html     -p venus_ss
-venus:          -p venus_common -p do_launch -p no_stop
+venus:          -p venus_common -p do_launch
 
 earp_common:   DEVICE_TARGET=<%= devices[:earp][:udid] %> DEVICE_ENDPOINT=<%= devices[:earp][:ip] %> -p device_common  -p iphone   -p earp_html     -p earp_ss
-earp:          -p earp_common -p do_launch -p no_stop
+earp:          -p earp_common -p do_launch
 


### PR DESCRIPTION
On Jenkins, we should reduce the console spam and just use the cucumber progress formatter.

Also, we should quit the sim when we are done.
