### PR TITLE
Don't build dylibs on jenkins jobs

### DIFF
--- a/script/ci/jenkins/run-develop.rb
+++ b/script/ci/jenkins/run-develop.rb
@@ -86,6 +86,7 @@ def run_develop(xtc_device_set, xtc_profile, xtc_series)
          {
                'CALABASH_SERVER_PATH' => server_dir,
                'CALABASH_GEM_PATH' => calabash_gem_dir,
+               'CALABASH_NO_DYLIBS' => '1'
          }
 
     File.open('.env', 'a') { |f|

--- a/script/ci/jenkins/run-masters.rb
+++ b/script/ci/jenkins/run-masters.rb
@@ -86,7 +86,8 @@ def run_masters(xtc_device_set, xtc_profile, xtc_series)
          {
                'CALABASH_SERVER_PATH' => server_dir,
                'CALABASH_GEM_PATH' => calabash_gem_dir,
-               'XTC_SERIES' => xtc_series
+               'XTC_SERIES' => xtc_series,
+               'CALABASH_NO_DYLIBS' => '1'
          }
 
     do_system('bundle exec briar install calabash-server',


### PR DESCRIPTION
Requires code signing which is not configured on Jenkins.

Jenkins CI needs love #42
